### PR TITLE
feat: optimize beacon validator lookup

### DIFF
--- a/pkg/sync/validator_events.go
+++ b/pkg/sync/validator_events.go
@@ -238,18 +238,16 @@ func SyncValidatorEvents(
 	if err != nil {
 		return fmt.Errorf("failed to get beacon validators: %w", err)
 	}
+	beaconValidatorsByPublicKey := make(map[phase0.BLSPubKey]*v1.Validator)
+	for _, v := range beaconValidators {
+		beaconValidatorsByPublicKey[v.Validator.PublicKey] = v
+	}
 	for pk, active := range knownValidators {
-		var beaconValidator *v1.Validator
-		for _, v := range beaconValidators {
-			if v.Validator.PublicKey == pk {
-				beaconValidator = v
-				break
-			}
-		}
 		validator := models.Validator{
 			PublicKey: hex.EncodeToString(pk[:]),
 			Active:    active,
 		}
+		beaconValidator := beaconValidatorsByPublicKey[pk]
 		if beaconValidator != nil {
 			validator.Index = null.IntFrom(int(beaconValidator.Index))
 			validator.BeaconStatus = null.StringFrom(beaconValidator.Status.String())


### PR DESCRIPTION
Optimizes the process of finding beacon validator information within the `SyncValidatorEvents` function.

Previously, the code iterated through the `beaconValidators` slice for each `knownValidator`. This change introduces a map (`beaconValidatorsByPublicKey`) to store beacon validators keyed by their public key, allowing for direct O(1) lookups instead of O(n) searches within the loop. This significantly improves performance, especially when dealing with a large number of validators.